### PR TITLE
Implement __serialize and __unserialize in RbacCollector

### DIFF
--- a/src/Collector/RbacCollector.php
+++ b/src/Collector/RbacCollector.php
@@ -220,21 +220,32 @@ class RbacCollector implements CollectorInterface, Serializable
      */
     public function serialize()
     {
-        return serialize($this->getCollection());
+        return serialize($this->__serialize());
     }
 
     /**
      * {@inheritDoc}
      */
-    public function unserialize($serialized)
+    public function unserialize($data)
     {
-        $collection = unserialize($serialized);
+        $collection = unserialize($data);
         if (!is_array($collection)) {
             throw new InvalidArgumentException(__METHOD__ . ": Unserialized data should be an array.");
         }
-        $this->collectedGuards = $collection['guards'];
-        $this->collectedRoles  = $collection['roles'];
-        $this->collectedPermissions =  $collection['permissions'];
-        $this->collectedOptions = $collection['options'];
+
+        $this->__unserialize($collection);
+    }
+
+    public function __serialize(): array
+    {
+        return $this->getCollection();
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->collectedGuards = $data['guards'];
+        $this->collectedRoles  = $data['roles'];
+        $this->collectedPermissions =  $data['permissions'];
+        $this->collectedOptions = $data['options'];
     }
 }

--- a/tests/Collector/RbacCollectorTest.php
+++ b/tests/Collector/RbacCollectorTest.php
@@ -147,14 +147,14 @@ class RbacCollectorTest extends \PHPUnit\Framework\TestCase
         $identity = $this->createMock(IdentityInterface::class);
 //        $identity = $this->getMock('LmcRbacMvc\Identity\IdentityInterface');
         $identity->expects($this->once())
-                 ->method('getRoles')
-                 ->will($this->returnValue($dataToCollect['identity_role']));
+            ->method('getRoles')
+            ->will($this->returnValue($dataToCollect['identity_role']));
 
 //        $identityProvider = $this->getMock('LmcRbacMvc\Identity\IdentityProviderInterface');
         $identityProvider = $this->createMock(\LmcRbacMvc\Identity\IdentityProviderInterface::class);
         $identityProvider->expects($this->once())
-                         ->method('getIdentity')
-                         ->will($this->returnValue($identity));
+            ->method('getIdentity')
+            ->will($this->returnValue($identity));
 
         $roleService = new RoleService($identityProvider, new InMemoryRoleProvider($dataToCollect['role_config']), new RecursiveRoleIteratorStrategy());
 
@@ -305,19 +305,19 @@ class RbacCollectorTest extends \PHPUnit\Framework\TestCase
             new RecursiveRoleIteratorStrategy()
         );
         $serviceManager->setService('LmcRbacMvc\Service\RoleService', $roleService);
-/*
-        $serviceManager->expects($this->at(0))
-            ->method('get')
-            ->with('LmcRbacMvc\Service\RoleService')
-            ->will($this->returnValue($roleService));
-*/
+        /*
+                $serviceManager->expects($this->at(0))
+                    ->method('get')
+                    ->with('LmcRbacMvc\Service\RoleService')
+                    ->will($this->returnValue($roleService));
+        */
         $serviceManager->setService('LmcRbacMvc\Options\ModuleOptions', new ModuleOptions());
-/*
-        $serviceManager->expects($this->at(1))
-            ->method('get')
-            ->with('LmcRbacMvc\Options\ModuleOptions')
-            ->will($this->returnValue(new ModuleOptions()));
-*/
+        /*
+                $serviceManager->expects($this->at(1))
+                    ->method('get')
+                    ->with('LmcRbacMvc\Options\ModuleOptions')
+                    ->will($this->returnValue(new ModuleOptions()));
+        */
         $collector = new RbacCollector();
         $collector->collect($mvcEvent);
 


### PR DESCRIPTION
Avoid deprecation warning on PHP 8.1
Implementing Serializable interface without implementing the new magic methods `__serialize` and `__unserialize`