### PR TITLE
Remove unused direct dependency on abandoned laminas-config.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
     "prefer-stable": true,
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-        "laminas/laminas-config": "^3.1",
         "laminas/laminas-eventmanager": "^3.0",
         "laminas/laminas-mvc": "^3.0",
         "laminas/laminas-servicemanager": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f4495837f11020f50f04c1fc986043e",
+    "content-hash": "f7b04093886e6dc0edcad9a807aaa930",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -244,16 +244,16 @@
         },
         {
             "name": "laminas/laminas-config",
-            "version": "3.10.0",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-config.git",
-                "reference": "b79e7dbd01889e4574526cf8d2b18f9d5b18384c"
+                "reference": "0f50adbf2b2e01e0fe99c13e37d3a6c1ef645185"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/b79e7dbd01889e4574526cf8d2b18f9d5b18384c",
-                "reference": "b79e7dbd01889e4574526cf8d2b18f9d5b18384c",
+                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/0f50adbf2b2e01e0fe99c13e37d3a6c1ef645185",
+                "reference": "0f50adbf2b2e01e0fe99c13e37d3a6c1ef645185",
                 "shasum": ""
             },
             "require": {
@@ -309,7 +309,7 @@
                 }
             ],
             "abandoned": true,
-            "time": "2024-11-17T22:10:53+00:00"
+            "time": "2024-12-05T14:32:05+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -5802,13 +5802,13 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.1.99"
     },


### PR DESCRIPTION
|    Q          | A      |
|-------------- |--------|
| Documentation | no |
| Bugfix        | no |
| BC Break      | no |
| New Feature   |no |
| RFC           | no |
| QA            | yes |

### Description

The laminas-config library has been abandoned. This component has a direct dependency on laminas-config in composer.json, yet it does not use any code in the Laminas\Config namespace; thus, I do not believe this direct dependency is needed.

Note that because laminas-modulemanager still depends on laminas-config, the changes here will not actually change which dependencies get installed... but I expect that laminas-modulemanager will eventually drop laminas-config, and when that happens, removing the abandoned dependency here should prove helpful.